### PR TITLE
Minor fix for gShouldUseRandomColors

### DIFF
--- a/script.gs
+++ b/script.gs
@@ -383,7 +383,7 @@ function initializeGlobalParametersIfNeeded() {
   gWelcomeStartButton = parametersData[4][1];
   gEndMessage = parametersData[5][1];
   gDoNotUnderstandMessage = parametersData[6][1];
-  gShouldUseRandomColors = parametersData[7][1];
+  gShouldUseRandomColors = parametersData[7][1].toLowerCase() === 'true';
   gDefaultKeyboardColor = parametersData[8][1];
 }
 


### PR DESCRIPTION
The example sheet states that "Should keyboard use random colors" can be  (TRUE/FALSE), which won't work if user enters FALSE. :)